### PR TITLE
numpydoc 1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.0" %}
+{% set version = "1.2" %}
 
 package:
   name: numpydoc
@@ -7,7 +7,7 @@ package:
 source:
   fn: numpydoc-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/n/numpydoc/numpydoc-{{ version }}.tar.gz
-  sha256: c36fd6cb7ffdc9b4e165a43f67bf6271a7b024d0bb6b00ac468c9e2bfc76448e
+  sha256: 0cec233740c6b125913005d16e8a9996e060528afcb8b7cad3f2706629dfd6f7
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,38 +1,46 @@
+{% set name = "numpydoc" %}
 {% set version = "1.2" %}
 
 package:
-  name: numpydoc
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: numpydoc-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/n/numpydoc/numpydoc-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/numpydoc-{{ version }}.tar.gz
   sha256: 0cec233740c6b125913005d16e8a9996e060528afcb8b7cad3f2706629dfd6f7
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
     - setuptools
-
+    - wheel
   run:
-    - python >=3.5
-    - sphinx
+    - python >=3.7
+    - jinja2 >=2.10
+    - sphinx >=1.8
 
 test:
   imports:
     - numpydoc
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/numpy/numpydoc
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: Numpy's Sphinx extensions
+  dev_url: https://github.com/numpy/numpydoc
+  doc_url: https://numpydoc.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update numpydoc to 1.2

Version change: bump version number from 1.1.0 to 1.2
Bug Tracker: new open issues https://github.com/numpy/numpydoc/issues
Github changelog:  https://github.com/numpy/numpydoc/blob/main/doc/release_notes.rst
License: https://github.com/numpy/numpydoc/blob/main/LICENSE.txt
Upstream setup.py:  https://github.com/numpy/numpydoc/blob/v1.2.0/setup.py

The package numpydoc is mentioned inside the packages:
spyder |

Actions:
1. Use jinja2 templates in urls
2. Reset build number to `0`
3. Fix python in `host`
4. Add `wheel` in `host`
5. Use `python >=3.7` in `run`
6. Add `jinja2 >=2.10` and use `sphinx >=1.8` in run
7. Add `pip check`
8. Add dev and doc urls
9. Add license_family

Result:
- all-succeeded
