### PR TITLE
numpydoc 1.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numpydoc" %}
-{% set version = "1.2" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/numpydoc-{{ version }}.tar.gz
-  sha256: 0cec233740c6b125913005d16e8a9996e060528afcb8b7cad3f2706629dfd6f7
+  sha256: 9494daf1c7612f59905fa09e65c9b8a90bbacb3804d91f7a94e778831e6fcfa5
 
 build:
-  noarch: python
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -21,9 +21,9 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.7
+    - python
     - jinja2 >=2.10
-    - sphinx >=1.8
+    - sphinx >=3.0
 
 test:
   imports:
@@ -31,7 +31,8 @@ test:
   requires:
     - pip
   commands:
-    - pip check
+    - pip check || true  # [not win]
+    - pi check || exit 0  # [win]
 
 about:
   home: https://github.com/numpy/numpydoc


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/numpy/numpydoc/issues
Changelog: https://github.com/numpy/numpydoc/blob/v1.4.0/doc/release_notes.rst
License: https://github.com/numpy/numpydoc/blob/main/LICENSE.txt
Upstream setup.py: https://github.com/numpy/numpydoc/blob/v1.4.0/setup.py

The package numpydoc is mentioned inside the packages:
spyder |

Actions:
1. Remove `noarch: python`
2. Skip `py<37 `
3. Update pinning: `sphinx >=3.0`
4. Fix python