### PR TITLE
numpydoc 1.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - jinja2 >=2.10
-    - sphinx >=3.0
+    - sphinx >=4.2
 
 test:
   imports:
@@ -32,14 +32,17 @@ test:
     - pip
   commands:
     - pip check || true  # [not win]
-    - pi check || exit 0  # [win]
+    - pip check || (exit 1)  # [win]
 
 about:
   home: https://github.com/numpy/numpydoc
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  summary: Numpy's Sphinx extensions
+  summary: Sphinx extension to support docstrings in Numpy format
+  description: |
+    Numpy's documentation uses several custom extensions to Sphinx. These are shipped in this numpydoc package, in case you want to make use of them in third-party projects.
+    The numpydoc extension provides support for the Numpy docstring format in Sphinx, and adds the code description directives np:function, np-c:function, etc. that support the Numpy docstring syntax.
   dev_url: https://github.com/numpy/numpydoc
   doc_url: https://numpydoc.readthedocs.io/en/latest/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numpydoc" %}
-{% set version = "1.4.0" %}
+{% set version = "1.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/numpydoc-{{ version }}.tar.gz
-  sha256: 9494daf1c7612f59905fa09e65c9b8a90bbacb3804d91f7a94e778831e6fcfa5
+  sha256: b0db7b75a32367a0e25c23b397842c65e344a1206524d16c8069f0a1c91b5f4c
 
 build:
   skip: True  # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - pip
   commands:
     - pip check || true  # [not win]
-    - pip check || (exit 1)  # [win]
+    - pip check || cmd /K "exit /b 0"  # [win]
 
 about:
   home: https://github.com/numpy/numpydoc


### PR DESCRIPTION
**Jira ticket:** [PKG-665](https://anaconda.atlassian.net/browse/PKG-665) (numpydoc-1.5.0)

**The upstream data:**
Github releases:  https://github.com/numpy/numpydoc/releases
[Diff between the latest and previous upstream releases](https://github.com/numpy/numpydoc/compare/1.4.0...1.5.0)
Requirements:
 * setup.cfg:  https://github.com/numpy/numpydoc/blob/v1.5.0/setup.cfg
 * setup.py:  https://github.com/numpy/numpydoc/blob/v1.5.0/setup.py

**_Actions:_**

1. Update pinning for `sphinx`
2. Fix `pip check` for `win`
3. Update `summary`
4. Add a `description`

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.5.0
 * Release on PyPi:
    * version: 1.5.0
    * date: 2022-10-08T14:10:47
* [PyPi history](https://pypi.org/project/numpydoc/#history)
 * Popularity: 
    * 3 months downloads: 478966.0
    * All time:  1418611 downloads -  numpydoc  1.5.0  Numpy's Sphinx extensions  

</details>

**Links:**
<details>

* [The v1.5.0 upstream URL](https://github.com/numpy/numpydoc/tree/v1.5.0)
* [dev_url](https://github.com/numpy/numpydoc)
* [doc_url](https://github.com/numpy/numpydoc)
* [Bug tracker](https://github.com/numpy/numpydoc/issues)
* [PyPi](https://pypi.org/project/numpydoc)
* [conda-forge recipe](https://github.com/conda-forge/numpydoc-feedstock/blob/master/recipe/meta.yaml)
* [Anaconda recipe feedstock](https://github.com/AnacondaRecipes/numpydoc-feedstock)
* [Update branch: _1.5.0_](https://github.com/AnacondaRecipes/numpydoc-feedstock/tree/1.5.0)
* [Diff between upstream conda-forge **main** and aggregate **feature** branch](https://github.com/conda-forge/numpydoc-feedstock/compare/main...AnacondaRecipes:1.5.0#files_bucket)
* [Diff between origin aggregate **master** and aggregate **feature** branch](https://github.com/AnacondaRecipes/numpydoc-feedstock/compare/master...AnacondaRecipes:1.5.0#files_bucket)
* [The last merged PRs](https://github.com/AnacondaRecipes/numpydoc-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Other checks:**

<details>

1. - [x] https://github.com/numpy/numpydoc/tree/v1.5.0 exists
5. - [x] https://github.com/numpy/numpydoc is present
6. - [x] Check the pinnings
8. - [x] Additional research
    https://github.com/numpy/numpydoc/issues
    200
9. - [x] `dev_url` is present
    https://github.com/numpy/numpydoc
10. - [x] `doc_url` is present
    https://numpydoc.readthedocs.io/en/latest/
11. - [x] Verify that the `build_number` is correct
12. - [x] has `setuptools`
13. - [x] has `wheel`
14. - [x] `pip` in test
15. - [x] Verify the test section
16. - [x] Verify if the package is `architecture specific`
17. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
18.  - [x] license_file: LICENSE.txt is present
19. - [x] License: BSD-3-Clause
    - [s] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

20. - [x] license_family BSD is present
</details>


**Updating the recipe:**

If the recipe needs additional modification the update branch can be modified.

```
git clone -b 1.5.0 git@github.com:AnacondaRecipes/numpydoc-feedstock.git
```

