### PR TITLE
numpydoc 1.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/alabaster-feedstock/pr2/f30b97b
+  - https://staging.continuum.io/prefect/fs/sphinxcontrib-serializinghtml-feedstock/pr3/865ced1
+  - https://staging.continuum.io/prefect/fs/sphinx-feedstock/pr17/3749e04

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/alabaster-feedstock/pr2/f30b97b
-  - https://staging.continuum.io/prefect/fs/sphinxcontrib-serializinghtml-feedstock/pr3/865ced1
-  - https://staging.continuum.io/prefect/fs/sphinx-feedstock/pr17/3749e04

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numpydoc" %}
-{% set version = "1.5.0" %}
+{% set version = "1.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/numpydoc-{{ version }}.tar.gz
-  sha256: b0db7b75a32367a0e25c23b397842c65e344a1206524d16c8069f0a1c91b5f4c
+  sha256: 866e5ae5b6509dcf873fc6381120f5c31acf13b135636c1a81d68c166a95f921
 
 build:
   skip: True  # [py<37]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
@@ -22,17 +22,20 @@ requirements:
     - wheel
   run:
     - python
-    - jinja2 >=2.10
-    - sphinx >=4.2
+    - sphinx >=6
+    - tabulate >=0.8.10
+    - tomli >=1.1.0  # [py311]
 
 test:
   imports:
     - numpydoc
   requires:
     - pip
+    - pytest
+    - matplotlib-base
   commands:
-    - pip check || true  # [not win]
-    - pip check || cmd /K "exit /b 0"  # [win]
+    - pip check
+    - pytest --pyargs numpydoc
 
 about:
   home: https://github.com/numpy/numpydoc
@@ -44,7 +47,7 @@ about:
     Numpy's documentation uses several custom extensions to Sphinx. These are shipped in this numpydoc package, in case you want to make use of them in third-party projects.
     The numpydoc extension provides support for the Numpy docstring format in Sphinx, and adds the code description directives np:function, np-c:function, etc. that support the Numpy docstring syntax.
   dev_url: https://github.com/numpy/numpydoc
-  doc_url: https://numpydoc.readthedocs.io/en/latest/
+  doc_url: https://numpydoc.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://github.com/numpy/numpydoc
-  license: BSD-3-Clause
+  license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE.txt
   summary: Sphinx extension to support docstrings in Numpy format

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python
     - sphinx >=6
     - tabulate >=0.8.10
-    - tomli >=1.1.0  # [py311]
+    - tomli >=1.1.0  # [py<311]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: 866e5ae5b6509dcf873fc6381120f5c31acf13b135636c1a81d68c166a95f921
 
 build:
-  skip: True  # [py<37]
+  # sphinx >=7.2.0 requires py>=39, we didn't build sphinx >5.0.2,<7.3.7.
+  skip: True  # [py<39]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 


### PR DESCRIPTION

**Destination channel:** main

### Links

- [PKG-5074](https://anaconda.atlassian.net/browse/PKG-5074)
- release-notes-tagged: https://github.com/numpy/numpydoc/releases
- release-diff: https://github.com/numpy/numpydoc/compare/v1.5.0...v1.7.0
- license: https://github.com/numpy/numpydoc/blob/main/LICENSE.txt
- requirements-tagged:
  - https://github.com/numpy/numpydoc/blob/v1.7.0/pyproject.toml
  - https://github.com/numpy/numpydoc/tree/v1.7.0/requirements


### Explanation of changes:

- Update runtime dependencies
- Enable `pip check`
- Add `pytest`
- Fix `doc_url`

[PKG-5074]: https://anaconda.atlassian.net/browse/PKG-5074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ